### PR TITLE
Debug and reconnection procedure

### DIFF
--- a/messenger/engine.py
+++ b/messenger/engine.py
@@ -61,6 +61,12 @@ class Engine:
         upstream_messages = self.serialize_messages([upstream_message])
         return upstream_messages
 
+    def get_messenger(self, messenger_id):
+        for messenger in self.messengers:
+            if messenger.identifier == messenger_id:
+                return messenger
+        return None
+
     async def send_messages(self, messenger_id: str, messages):
         upstream_messages_data = b''
         for messenger in self.messengers:

--- a/messenger/forwarders.py
+++ b/messenger/forwarders.py
@@ -27,6 +27,16 @@ class ForwarderClient:
                 if not upstream_message:
                     break
                 self.messenger.sent_bytes += len(upstream_message)
+                self.messenger.update_cli.display(
+                    f'Forwarder Client {self.identifier} sent {len(upstream_message)} bytes.',
+                    'debug',
+                    debug_level=3
+                )
+                self.messenger.update_cli.display(
+                    f'Forwarder Client {self.identifier} sent\n{upstream_message}.',
+                    'debug',
+                    debug_level=6
+                )
                 await self.messenger.send_message_upstream(
                     SendDataMessage(
                         forwarder_client_id=self.identifier,
@@ -44,6 +54,16 @@ class ForwarderClient:
 
     def write(self, data):
         self.messenger.received_bytes += len(data)
+        self.messenger.update_cli.display(
+            f'Forwarder Client {self.identifier} received {len(data)} bytes.',
+            'debug',
+            debug_level=3
+        )
+        self.messenger.update_cli.display(
+            f'Forwarder Client {self.identifier} received\n{data}.',
+            'debug',
+            debug_level=6
+        )
         self.writer.write(data)
 
 

--- a/messenger/http_ws_server.py
+++ b/messenger/http_ws_server.py
@@ -70,7 +70,7 @@ class HTTPWSServer:
         self.update_cli.display(
             f'The HTTP handler received the following data\n{data}.',
             'debug',
-            debug_level = 2
+            debug_level = 4
         )
         messages = self.messenger_engine.deserialize_messages(data)
         messenger_id = self.messenger_engine.get_messenger_id(messages[0])
@@ -111,7 +111,7 @@ class HTTPWSServer:
         self.update_cli.display(
             f'The WS handler received the following data\n{msg.data}.',
             'debug',
-            debug_level=2
+            debug_level=4
         )
         messages = self.messenger_engine.deserialize_messages(msg.data)
         messenger_id = self.messenger_engine.get_messenger_id(messages[0])

--- a/messenger/manager.py
+++ b/messenger/manager.py
@@ -320,6 +320,16 @@ class Manager:
         """
         Set the debug level for CLI output.
 
+        Debug Level | Scope                           | Description
+        ------------|---------------------------------|---------------------------------------------------------
+        0           | None                            | No debug output
+        1           | Handler Messages                | Handler received/sent messages
+        2           | Messenger Messages              | Messenger received/sent messages
+        3           | Forwarder Clients Messages      | Forwarder clients received/sent messages
+        4           | Handler Data                    | Handler received/sent raw data
+        5           | Messenger Data                  | Messenger received/sent raw data
+        6           | Forwarder Clients Data          | Forwarder clients received/sent raw data
+
         required:
           level        The numeric debug level
 

--- a/messenger/manager.py
+++ b/messenger/manager.py
@@ -31,7 +31,7 @@ class UpdateCLI:
     Status = namedtuple('Status', ['icon', 'color'])
 
     STATUS_LEVELS = {
-        'debug': Status('[DBG]', 'white'),
+        'debug': Status('[DBG {}]', 'white'),
         'information': Status('[*]', 'cyan'),
         'warning': Status('[!]', 'yellow'),
         'error': Status('[-]', 'red'),
@@ -49,23 +49,19 @@ class UpdateCLI:
         """
         self.prompt = prompt
         self.session = session
-        self.debug = False
+        self.debug_level = 0
 
-    def display(self, stdout, status='standard', reprompt=True):
-        """
-        Display output with a status icon and optionally reprompt.
-
-        Args:
-            stdout (str): The output message to display.
-            status (str): The status level for the message (e.g., 'debug', 'information', 'warning').
-            reprompt (bool): If True, reprompts with the current buffer content.
-        """
+    def display(self, stdout, status='standard', reprompt=True, debug_level=0):
         status_info = self.STATUS_LEVELS.get(status, self.STATUS_LEVELS['information'])
 
-        if status == 'debug' and not self.debug:
-            return
+        if status == 'debug':
+            if self.debug_level < debug_level:
+                return
+            icon_label = status_info.icon.format(debug_level)
+            icon = self.color_text(icon_label, status_info.color)
+        else:
+            icon = self.color_text(status_info.icon, status_info.color)
 
-        icon = self.color_text(status_info.icon, status_info.color)
         print(f'\r{icon} {stdout}')
 
         if reprompt:
@@ -136,6 +132,7 @@ class Manager:
         """
         self.server_commands = {
             'build': (self.build, "Builds a messenger client."),
+            'debug': (self.debug, "Set the debug level."),
             'forwarders': (self.print_forwarders, "Display a list of forwarders in a table format."),
             'messengers': (self.print_messengers, "Display a list of messengers in a table format."),
             'scans': (self.print_scanners, "Display a list of scanners in a table format."),
@@ -318,6 +315,25 @@ class Manager:
         Return to the main menu.
         """
         self.current_messenger = None
+
+    async def debug(self, level: int):
+        """
+        Set the debug level for CLI output.
+
+        required:
+          level        The numeric debug level
+
+        examples:
+          debug 0
+        """
+        try:
+            level = int(level)
+        except ValueError:
+            self.update_cli.display("Debug level must be an integer.", "error", reprompt=False)
+            return
+
+        self.update_cli.debug_level = level
+        self.update_cli.display(f"Debug level set to {level}.", "success", reprompt=False)
 
     async def build(self, messenger_client_type, no_obfuscate=False, name="messenger-client"):
         """

--- a/messenger/messengers.py
+++ b/messenger/messengers.py
@@ -54,14 +54,14 @@ class Messenger:
     @abstractmethod
     async def send_messages_downstream(self, messages):
         self.update_cli.display(
-            f'Messenger {self.identifier} received a downstream message(s).',
+            f'Messenger {self.identifier} received downstream message(s).',
             'debug',
             debug_level = 2
         )
         self.update_cli.display(
             f'Messenger {self.identifier} received the following downstream message(s)\n{messages}.',
             'debug',
-            debug_level = 3
+            debug_level = 5
         )
         for message in messages:
             # 1) Initiate Forwarder Client Request (0x01)
@@ -180,7 +180,7 @@ class HTTPMessenger(Messenger):
         self.update_cli.display(
             f'Messenger {self.identifier} sent the following upstream message\n{message}.',
             'debug',
-            debug_level = 3
+            debug_level = 5
         )
         await self.upstream_messages.put(self.serialize_messages([message]))
 
@@ -251,6 +251,6 @@ class WebSocketMessenger(Messenger):
         self.update_cli.display(
             f'Messenger {self.identifier} sent the following upstream message\n{message}.',
             'debug',
-            debug_level = 3
+            debug_level = 5
         )
         await self.websocket.send_bytes(self.serialize_messages([message]))

--- a/messenger/messengers.py
+++ b/messenger/messengers.py
@@ -14,7 +14,6 @@ class Messenger:
     transport_type = 'undefined'
 
     def __init__(self, update_cli, serialize_messages):
-        self.alive = True
         self.identifier = alphanumeric_identifier()
         self.update_cli = update_cli
         self.forwarders = []
@@ -22,14 +21,17 @@ class Messenger:
         self.upstream_messages = asyncio.Queue()
         self.serialize_messages = serialize_messages
 
+        # utility for non-stateful Messengers like HTTP
+        self.last_check_in = time.time()
+
         # Private raw counters
         self.sent_bytes = 0
         self.received_bytes = 0
 
+        asyncio.create_task(self.expiration())
+
+
     async def get_upstream_messages(self):
-        if self.alive == False:
-            self.alive = True
-            self.update_cli.display(f'{self.transport_type} Messenger `{self.identifier}` has reconnected.', 'success')
         self.last_check_in = time.time()
         upstream_messages = b''
         while not self.upstream_messages.empty():
@@ -37,12 +39,30 @@ class Messenger:
 
         return upstream_messages
 
+    @property
+    def alive(self):
+        raise NotImplementedError
+
+    @property
+    def expiration(self):
+        raise NotImplementedError
+
     @abstractmethod
     async def send_message_upstream(self, message):
         raise NotImplementedError
 
     @abstractmethod
     async def send_messages_downstream(self, messages):
+        self.update_cli.display(
+            f'Messenger {self.identifier} received a downstream message(s).',
+            'debug',
+            debug_level = 2
+        )
+        self.update_cli.display(
+            f'Messenger {self.identifier} received the following downstream message(s)\n{messages}.',
+            'debug',
+            debug_level = 3
+        )
         for message in messages:
             # 1) Initiate Forwarder Client Request (0x01)
             if isinstance(message, InitiateForwarderClientReq):
@@ -137,10 +157,13 @@ class HTTPMessenger(Messenger):
 
     def __init__(self, ip, user_agent, update_cli, serialize_messages):
         super().__init__(update_cli, serialize_messages)
-        asyncio.create_task(self.expiration())
         self.ip = ip
         self.user_agent = user_agent
-        self.last_check_in = time.time()
+        self.disconnected = False
+
+    @property
+    def alive(self):
+        return not self.disconnected
 
     async def send_message_upstream(self, message):
         if not self.alive:
@@ -149,31 +172,37 @@ class HTTPMessenger(Messenger):
                 'warning'
             )
             return
+        self.update_cli.display(
+            f'Messenger {self.identifier} sent a upstream message.',
+            'debug',
+            debug_level = 2
+        )
+        self.update_cli.display(
+            f'Messenger {self.identifier} sent the following upstream message\n{message}.',
+            'debug',
+            debug_level = 3
+        )
         await self.upstream_messages.put(self.serialize_messages([message]))
 
     async def expiration(self):
+        disconnection_rate = 30
         while True:
             await asyncio.sleep(10)
             expired = int(time.time() - self.last_check_in)
-            if expired >= 30:
-                self.alive = False
-                self.update_cli.display(
-                    f'{self.transport_type} Messenger `{self.identifier}` has disconnected.',
-                    'warning'
-                )
-                break
-            elif expired >= 20:
-                self.update_cli.display(
-                    f'{self.transport_type} Messenger `{self.identifier}` has not checked in the past 20 seconds '
-                    'and will disconnect soon.',
-                    'warning'
-                )
-            elif expired >= 10:
-                self.update_cli.display(
-                    f'{self.transport_type} Messenger `{self.identifier}` has not checked in the past 10 seconds '
-                    'and will disconnect soon.',
-                    'warning'
-                )
+            if expired >= disconnection_rate:
+                if not self.disconnected:
+                    self.disconnected = True
+                    self.update_cli.display(
+                        f'{self.transport_type} Messenger `{self.identifier}` has not checked in within the past `{disconnection_rate}` seconds and is now set to disconnected.',
+                        'warning'
+                    )
+            else:
+                if self.disconnected:
+                    self.update_cli.display(
+                        f'{self.transport_type} Messenger `{self.identifier}` has reconnected.',
+                        'success'
+                    )
+                self.disconnected = False
 
 class WebSocketMessenger(Messenger):
 
@@ -185,6 +214,28 @@ class WebSocketMessenger(Messenger):
         self.user_agent = user_agent
         self.websocket = websocket
 
+    @property
+    def alive(self):
+        return not self.websocket.closed
+
+    def set_websocket(self, ws):
+        self.websocket = ws
+        self.update_cli.display(
+            f'{self.transport_type} Messenger `{self.identifier}` has reconnected.',
+            'success'
+        )
+        asyncio.create_task(self.expiration())
+
+    async def expiration(self):
+        while True:
+            await asyncio.sleep(10)
+            if not self.alive:
+                self.update_cli.display(
+                    f'{self.transport_type} Messenger `{self.identifier}` has disconnected.',
+                    'warning'
+                )
+            break
+
     async def send_message_upstream(self, message):
         if not self.alive:
             self.update_cli.display(
@@ -192,4 +243,14 @@ class WebSocketMessenger(Messenger):
                 'warning'
             )
             return
+        self.update_cli.display(
+            f'Messenger {self.identifier} sent a upstream message.',
+            'debug',
+            debug_level = 2
+        )
+        self.update_cli.display(
+            f'Messenger {self.identifier} sent the following upstream message\n{message}.',
+            'debug',
+            debug_level = 3
+        )
         await self.websocket.send_bytes(self.serialize_messages([message]))


### PR DESCRIPTION
Added the necessary infrastructure to support a reconnection procedure and the debug command.

@Invoke-Mimikatz can you check the following;

I've pulled the new Python client to the submodule so you should be able to use `build python` for testing.

- [ ] The help menu for `debug` is adequate. 
- [ ] The `debug` command works as expected.
 - [ ] No additional messages needed
 - [ ] Messages are detailed and useful 
- [ ] The reconnection procedure is working as expected. 
 - [ ] Killed the server, and upon restarting, clients reconnected.
 - [ ] Somehow kill clients without completely shutting down, maybe put a workstation to sleep, and see if they reconnect properly?


### Skyler's ToDo
- [ ] Update C# client with new changes
- [ ] Update Python client with changes to status messages and/or reconnection procedure. 